### PR TITLE
チーム消せない問題

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,5 @@
 class Team < ApplicationRecord
-  has_many :progresses
+  has_many :progresses, dependent: :destroy
 
   validates :name, presence: true
   validates :goal, presence: true


### PR DESCRIPTION
関連するProgress や Topic が一緒に消えていないために、 Team が消せない問題が発生。
削除時に関連するレコードを全て消す用にした。