### PR TITLE
グラフの y軸を小数点刻みにしない

### DIFF
--- a/app/models/graph_creater.rb
+++ b/app/models/graph_creater.rb
@@ -33,6 +33,7 @@ class GraphCreater
             text: entity, margin: 70
           },
           max: max,
+          allowDecimals: false,
           plotLines: [
             {
               value: @team.goal,


### PR DESCRIPTION
Qiita より

> あと、目標件数に対してグラフのメモリが2.5刻みになってるのは変わるのかな？
> 件数に小数点以下がでるのは違和感あり。

今回の情報で使うのは、基本的に小数点出ない系の値だから、単位にかかわらず無効にしちゃって良さそう