### PR TITLE
発表順を示すorderカラムをTeamsテーブルに追加

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -70,7 +70,7 @@ class TeamsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def team_params
-    params.require(:team).permit(:name, :goal, :entity)
+    params.require(:team).permit(:name, :goal, :entity, :order)
   end
 
   def current_time

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -63,7 +63,8 @@ class TeamsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
+
+  # Use callbacks to share common setup or constraints between actions.
   def set_team
     @team = Team.find(params[:id])
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,7 +4,7 @@ class TeamsController < ApplicationController
   # GET /teams
   # GET /teams.json
   def index
-    @teams = Team.all
+    @teams = Team.all.order(:order)
   end
 
   # GET /teams/1

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,6 +7,9 @@ class Team < ApplicationRecord
 
   enum entity: { orders: 0, sales: 1 }
 
+  scope :prev_team, -> (order) { where('"order" < ?', order).order(:order).last }
+  scope :next_team, -> (order) { where('"order" > ?', order).order(:order).first }
+
   def graph(time)
     @graph = GraphCreator.new(self).create(time)
   end
@@ -27,5 +30,13 @@ class Team < ApplicationRecord
         precision: 0
       )
     end
+  end
+
+  def has_prev_team?
+    Team.exists?(['"order" < ?', self.order])
+  end
+
+  def has_next_team?
+    Team.exists?(['"order" > ?', self.order])
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,11 +32,11 @@ class Team < ApplicationRecord
     end
   end
 
-  def has_prev_team?
-    Team.exists?(['"order" < ?', self.order])
+  def self.has_prev_team?(order)
+    exists?(['"order" < ?', order])
   end
 
-  def has_next_team?
-    Team.exists?(['"order" > ?', self.order])
+  def self.has_next_team?(order)
+    exists?(['"order" > ?', order])
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,6 +3,7 @@ class Team < ApplicationRecord
 
   validates :name, presence: true
   validates :goal, presence: true
+  validates :order, presence: true, uniqueness: true
 
   enum entity: { orders: 0, sales: 1 }
 

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -20,7 +20,8 @@
 
         .form-group
           = button_tag type: "submit", class: 'btn btn-primary' do
-            span.glyphicon.glyphicon-ok.btn-icon 保存
+            span.glyphicon.glyphicon-ok.btn-icon
+            | 保存
 
       .col-xs-5.col-xs-offset-1
         table.table

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -12,16 +12,15 @@
 
         .form-group
           = f.label '目標種別'
-          = select_tag 'team[:entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
+          = select_tag 'team[entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
 
         .form-group
           = f.label '発表順'
-          = text_field_tag 'team[order]', Team.maximum(:order) + 1, class: 'form-control'
+          = text_field_tag 'team[order]', @team.order || Team.maximum(:order) + 1, class: 'form-control'
 
         .form-group
           = button_tag type: "submit", class: 'btn btn-primary' do
-            span.glyphicon.glyphicon-ok.btn-icon
-            | 保存
+            span.glyphicon.glyphicon-ok.btn-icon 保存
 
       .col-xs-5.col-xs-offset-1
         table.table

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -1,18 +1,39 @@
-= form_for(team) do |f|
-  - if team.errors.any?
-    #error_explanation
-      h2
-        = pluralize(team.errors.count, "error")
-        |  prohibited this team from being saved:
-      ul
-        - team.errors.full_messages.each do |message|
-          li
-            = message
-  .field
-    = f.label :name
-    = f.text_field :name
-  .field
-    = f.label :goal
-    = f.number_field :goal
-  .actions
-    = f.submit
+.container
+  = form_for @team do |f|
+    .row
+      .col-xs-4
+        .form-group
+          = f.label 'チーム名'
+          = f.text_field :name, class: 'form-control'
+
+        .form-group
+          = f.label '当月目標'
+          = f.text_field :goal, class: 'form-control'
+
+        .form-group
+          = f.label '目標種別'
+          = select_tag 'team[:entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
+
+        .form-group
+          = f.label '発表順'
+          = text_field_tag 'team[order]', Team.maximum(:order) + 1, class: 'form-control'
+
+        .form-group
+          = button_tag type: "submit", class: 'btn btn-primary' do
+            span.glyphicon.glyphicon-ok.btn-icon
+            | 保存
+
+      .col-xs-5.col-xs-offset-1
+        table.table
+          caption 現在の発表順
+          thead
+            tr
+              th #
+              th チーム名
+          tbody
+            - Team.select(:name, :order).all.order(:order).each do |team|
+              tr
+                th
+                  = team.order
+                th
+                  = team.name

--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -16,7 +16,7 @@
 
         .form-group
           = f.label '発表順'
-          = text_field_tag 'team[order]', @team.order || Team.maximum(:order) + 1, class: 'form-control'
+          = text_field_tag 'team[order]', @team.order || (Team.maximum(:order) || 0) + 1, class: 'form-control'
 
         .form-group
           = button_tag type: "submit", class: 'btn btn-primary' do

--- a/app/views/teams/edit.html.slim
+++ b/app/views/teams/edit.html.slim
@@ -5,31 +5,7 @@
 .container
   hr
 
-.container
-  = form_for @team do |f|
-    .row
-      .col-xs-4
-        .form-group
-          = f.label 'チーム名'
-          = f.text_field :name, class: 'form-control'
-
-    .row
-      .col-xs-4
-        .form-group
-          = f.label '月間目標'
-          = f.text_field :goal, class: 'form-control'
-
-    .row
-      .col-xs-4
-        .form-group
-          = select_tag 'team[entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
-
-    .row
-      .col-xs-4
-        .form-group
-          = button_tag type: "submit", class: 'btn btn-primary' do
-            span.glyphicon.glyphicon-ok.btn-icon
-            | 保存
+= render partial: 'form'
 
 .container
   = link_to '戻る', teams_path, class: 'btn btn-default'

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -28,24 +28,29 @@
           td.right-align
             = link_to team_progresses_path(team) do
               button.btn.btn-success
-                span.glyphicon.glyphicon-wrench.btn-icon 実績管理
+                span.glyphicon.glyphicon-wrench.btn-icon
+                | 実績管理
 
           td.right-align
             = link_to edit_team_path(team) do
               button.btn.btn-success
-                span.glyphicon.glyphicon-wrench.btn-icon 月間目標編集
+                span.glyphicon.glyphicon-wrench.btn-icon
+                | 月間目標編集
 
           td.right-align
             = link_to team do
               button.btn.btn-default
-                span.glyphicon.glyphicon-stats.btn-icon プレビュー
+                span.glyphicon.glyphicon-stats.btn-icon
+                | プレビュー
 
           td.right-align
             = link_to team, method: :delete, data: { confirm: '削除してよろしいですか？' } do
               button.btn.btn-danger
-                span.glyphicon.glyphicon-trash.btn-icon チーム削除
+                span.glyphicon.glyphicon-trash.btn-icon
+                | チーム削除
 
 .container
   = link_to new_team_path do
     button.btn.btn-primary
-      span.glyphicon.glyphicon-plus.btn-icon チーム新規作成
+      span.glyphicon.glyphicon-plus.btn-icon
+      | チーム新規作成

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -28,29 +28,24 @@
           td.right-align
             = link_to team_progresses_path(team) do
               button.btn.btn-success
-                span.glyphicon.glyphicon-wrench.btn-icon
-                | 実績管理
+                span.glyphicon.glyphicon-wrench.btn-icon 実績管理
 
           td.right-align
             = link_to edit_team_path(team) do
               button.btn.btn-success
-                span.glyphicon.glyphicon-wrench.btn-icon
-                | 月間目標編集
+                span.glyphicon.glyphicon-wrench.btn-icon 月間目標編集
 
           td.right-align
             = link_to team do
               button.btn.btn-default
-                span.glyphicon.glyphicon-stats.btn-icon
-                | プレビュー
+                span.glyphicon.glyphicon-stats.btn-icon プレビュー
 
           td.right-align
             = link_to team, method: :delete, data: { confirm: '削除してよろしいですか？' } do
               button.btn.btn-danger
-                span.glyphicon.glyphicon-trash.btn-icon
-                | チーム削除
+                span.glyphicon.glyphicon-trash.btn-icon チーム削除
 
 .container
   = link_to new_team_path do
     button.btn.btn-primary
-      span.glyphicon.glyphicon-plus.btn-icon
-      | チーム新規作成
+      span.glyphicon.glyphicon-plus.btn-icon チーム新規作成

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -5,17 +5,20 @@
   hr
 
 .container
-  table.table.table-straiped
+  table.table.table-striped
     thead
       tr
-        th.centering
-          | チーム名
-        th.goal
-          | 月間目標
-        th[colspan="3"]
+        th #
+        th.centering チーム名
+        th.goal 月間目標
+        th[colspan="4"]
+
     tbody
       - @teams.each do |team|
         tr
+          td
+            = team.order
+
           td.centering
             = team.name
 

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -5,45 +5,7 @@
 .container
   hr
 
-.container
-  = form_tag("/teams", method: 'post') do
-    .row
-      .col-xs-4
-        .form-group
-          = label_tag 'チーム名'
-          = text_field_tag 'team[name]', nil, class: 'form-control'
-
-        .form-group
-          = label_tag '当月目標'
-          = text_field_tag 'team[goal]', 0, class: 'form-control'
-
-        .form-group
-          = label_tag '目標種別'
-          = select_tag 'team[entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
-
-        .form-group
-          = label_tag '発表順'
-          = text_field_tag 'team[order]', Team.maximum(:order) + 1, class: 'form-control'
-
-        .form-group
-          = button_tag type: "submit", class: 'btn btn-primary' do
-            span.glyphicon.glyphicon-ok.btn-icon
-            | 作成
-
-      .col-xs-5.col-xs-offset-1
-        table.table
-          caption 現在の発表順
-          thead
-            tr
-              th #
-              th チーム名
-          tbody
-            - Team.select(:name, :order).all.order(:order).each do |team|
-              tr
-                th
-                  = team.order
-                th
-                  = team.name
+= render partial: 'form'
 
 .container
   = link_to '戻る', teams_path, class: 'btn btn-default'

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -13,14 +13,10 @@
           = label_tag 'チーム名'
           = text_field_tag 'team[name]', nil, class: 'form-control'
 
-    .row
-      .col-xs-4
         .form-group
           = label_tag '当月目標'
           = text_field_tag 'team[goal]', 0, class: 'form-control'
 
-    .row
-      .col-xs-4
         .form-group
           = label_tag '目標種別'
           = select_tag 'team[entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -30,5 +30,20 @@
             span.glyphicon.glyphicon-ok.btn-icon
             | 作成
 
+      .col-xs-5.col-xs-offset-1
+        table.table
+          caption 現在の発表順
+          thead
+            tr
+              th #
+              th チーム名
+          tbody
+            - Team.select(:name, :order).all.order(:order).each do |team|
+              tr
+                th
+                  = team.order
+                th
+                  = team.name
+
 .container
   = link_to '戻る', teams_path, class: 'btn btn-default'

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -25,8 +25,10 @@
           = label_tag '目標種別'
           = select_tag 'team[entity]', options_for_select({ "受注件数 [件]": "orders", "売上 [円]": "sales" }), class: 'form-control selectpicker'
 
-    .row
-      .col-xs-4
+        .form-group
+          = label_tag '発表順'
+          = text_field_tag 'team[order]', Team.maximum(:order) + 1, class: 'form-control'
+
         .form-group
           = button_tag type: "submit", class: 'btn btn-primary' do
             span.glyphicon.glyphicon-ok.btn-icon

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -26,16 +26,18 @@
 
 .container
   ul.pager
-    - if Team.exists?(id: @team.id - 1)
+    - if @team.has_prev_team?
       li.previous
-        = link_to(team_path(@team.id - 1)) do
+        - prev_team = Team.prev_team(@team.order)
+        = link_to(team_path(prev_team.id)) do
           span aria-hidden="true"
             | &larr;&nbsp;
-          = Team.find(@team.id - 1).name
+          = prev_team.name
 
-    - if Team.exists?(id: @team.id + 1)
+    - if @team.has_next_team?
       li.next
-        = link_to(team_path(@team.id + 1)) do
-          = Team.find(@team.id + 1).name
+        - next_team = Team.next_team(@team.order)
+        = link_to(team_path(next_team.id)) do
+          = next_team.name
           span aria-hidden="true"
             | &nbsp;&rarr;

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -26,7 +26,7 @@
 
 .container
   ul.pager
-    - if @team.has_prev_team?
+    - if Team.has_prev_team?(@team.order)
       li.previous
         - prev_team = Team.prev_team(@team.order)
         = link_to(team_path(prev_team.id)) do
@@ -34,7 +34,7 @@
             | &larr;&nbsp;
           = prev_team.name
 
-    - if @team.has_next_team?
+    - if Team.has_next_team?(@team.order)
       li.next
         - next_team = Team.next_team(@team.order)
         = link_to(team_path(next_team.id)) do

--- a/db/migrate/20160728153406_add_order_to_teams.rb
+++ b/db/migrate/20160728153406_add_order_to_teams.rb
@@ -1,0 +1,5 @@
+class AddOrderToTeams < ActiveRecord::Migration[5.0]
+  def change
+    add_column :teams, :order, :integer, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160722083105) do
+ActiveRecord::Schema.define(version: 20160728153406) do
 
   create_table "progresses", force: :cascade do |t|
     t.integer  "team_id"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160722083105) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.integer  "entity",     default: 0
+    t.integer  "order"
   end
 
   create_table "topics", force: :cascade do |t|


### PR DESCRIPTION
### やりたかったこと

#44 
プレビュー画面にて、Teamに自動的に割り当てられる`id`が連番になっていないと、
次のチームへ遷移するボタンが出てこなかった。
また、チームの発表順が`id`依存になっており、変更が非常に難しかった。

そこで、チームの発表順を示す`order`カラムを`Teams`テーブルに追加し、
プレビュー画面での発表順制御などに利用する。


### やったこと

#44, ついでに `Team`に関する #37 。

- `Teams`テーブルに`order`カラムを追加 b3cbf28
- `order`を使用した発表順制御の実装 6c60ea2 ffeb4f9
  - 前後の発表チームがあるかどうかを判定する`Team#has_prev_team?`と`Team#has_next_team?`の実装
    - スコープではないクラスメソッドで実装
  - 前後のチームを取得する`Team.prev_team`と`Team.next_team`の実装
    - スコープとして実装
- 新規作成と編集で共通になっているフォームの切り出し f210dbd
- その他細々とした修正など

### やってないこと

順番変更専用の機能は実装していない。
チーム編集画面から順番変更はできるが、ユニークな番号しか許可していないので、
順番の入れ替え、特定の場所への差し込みなどの操作がとてもやりにくい。
後々専用の編集画面を作ったほうがいい気がする。