### PR TITLE
Fix merge miss on #47

### DIFF
--- a/lib/graph_creator.rb
+++ b/lib/graph_creator.rb
@@ -78,7 +78,7 @@ class GraphCreator
   end
 
   def category_day(progress)
-    "#{progress.start_date.day}〜#{(progress.start_date + 4).day}日"
+    "#{progress.start_date.day}〜#{(progress.end_date)&.day}日"
   end
 
   def series_data


### PR DESCRIPTION
### PRの目的

#47 でマージの時に発生した [正しくない？差分](https://github.com/pokotyamu/morning-meeting-chart/pull/47#discussion-diff-72418102) が未修正のまま取り込まれてしまったようなのでそれを直すPRです。

### 見てほしい人

[該当のコミット](https://github.com/pokotyamu/morning-meeting-chart/pull/47#discussion_r72419397) は @pokotyamu のものっぽいので、見てもらって問題なければマージをお願いします :pray: