### PR TITLE
CSSで棒グラフを透明化した

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -61,3 +61,7 @@ td {
 .btn-icon {
   margin-right: 0.3em;
 }
+
+div.highcharts-container rect {
+  fill-opacity: 0.6;
+}


### PR DESCRIPTION
透明度は0～1で調整可能。とりあえず`0.6`にしたけど適当な濃さかどうかはなんとも。

CSS側で透明化してるので、画像出力機能を使うと透明ではなくなる（はず）という問題はあったりするけど…