### PR TITLE
最新の進捗登録を一発で行いたい

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -12,7 +12,7 @@ class GoalsController < ApplicationController
   end
 
   def new
-    @goal = @team.goals.new
+    @goal = @team.goals.new(date: Date.current)
   end
 
   def create

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -27,7 +27,7 @@ class ProgressesController < ApplicationController
         end
       end
     end
-    redirect_to team_goal_progresses_path(team_id: params[:team_id], goal_id: params[:goal_id]), notice: '更新されました'
+    redirect_to team_path(params[:team_id]), notice: '更新されました'
   rescue
     redirect_to edit_team_goal_progress_path(team_id: params[:team_id], goal_id: params[:goal_id]),  alert: '入力に不備があります'
   end
@@ -39,7 +39,7 @@ class ProgressesController < ApplicationController
         @progress.topics.create!(content: val)
       end
     end
-    redirect_to team_goal_progresses_path(team_id: params[:team_id], goal_id: params[:goal_id]), notice: '作成されました'
+    redirect_to team_path(params[:team_id]), notice: '作成されました'
   rescue
     redirect_to new_team_goal_progress_path(team_id: params[:team_id], goal_id: params[:goal_id]),  alert: '入力に不備があります'
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,9 @@ class TeamsController < ApplicationController
   # GET /teams/1.json
   def show
     if can_create_graph?
-      @graph = Graph.create(@goals.last)
+      @goal = @goals.last
+      @graph = Graph.create(@goal)
+      @sum = @goal.progresses.sum(:amount)
     else
       redirect_to teams_path, alert: '目標や進捗を登録してからグラフを作成してください。'
     end
@@ -71,6 +73,7 @@ class TeamsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_team
     @team = Team.find(params[:id])
+    @entity = entity
     @goals = @team.goals.order(:date)
   end
 
@@ -81,5 +84,10 @@ class TeamsController < ApplicationController
 
   def can_create_graph?
     @goals.present? && @goals.last.progresses.present?
+  end
+
+  def entity
+    return '(件)' if @team.orders?
+    return '(円)' if @team.sales?
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,7 @@ class TeamsController < ApplicationController
   # GET /teams/1.json
   def show
     if can_create_graph?
-      @goal = @goals.last
+      @goal = @goals.order(:date).last
       @graph = Graph.create(@goal)
       @sum = @goal.progresses.sum(:amount)
     else

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,4 +16,8 @@ class Team < ApplicationRecord
   def self.has_next_team?(order)
     exists?(['"order" > ?', order])
   end
+
+  def current_month_goal?
+    goals.order(:date).last.date.month == Date.current.month if goals
+  end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -18,6 +18,13 @@ class Team < ApplicationRecord
   end
 
   def current_month_goal?
-    goals.order(:date).last.date.month == Date.current.month if goals
+    goals.order(:date).last.date.month == last_monday.month if goals
+  end
+
+  private
+
+  def last_monday
+    this_day = Date.today
+    (this_day - (this_day.wday - 1)) - 7
   end
 end

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -31,18 +31,18 @@
                 span.glyphicon.glyphicon-th-list.btn-icon
                 | 目標一覧
 
-          - if team.goals.present?
+          - if team.goals.present? && team.current_month_goal?
             td.right-align
               = link_to new_team_goal_progress_path(team, team.goals.order(:date).last)
                 button.btn.btn-primary
                   span.glyphicon.glyphicon-plus.btn-icon
-                  | 最新月に進捗追加
+                  | 先週の進捗追加
           - else
             td.right-align
               = link_to new_team_goal_path(team)
                 button.btn.btn-primary
                   span.glyphicon.glyphicon-plus.btn-icon
-                  | 目標の新規登録
+                  | 今月の目標追加
 
           td.right-align
             = link_to team do

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -45,22 +45,23 @@
                   | 目標の新規登録
 
           td.right-align
-            = link_to edit_team_path(team) do
-              button.btn.btn-success
-                span.glyphicon.glyphicon-wrench.btn-icon
-                | チーム編集
-
-          td.right-align
             = link_to team do
               button.btn.btn-default
                 span.glyphicon.glyphicon-stats.btn-icon
                 | プレビュー
 
-          td.right-align
-            = link_to team, method: :delete, data: { confirm: '削除してよろしいですか？' } do
-              button.btn.btn-danger
-                span.glyphicon.glyphicon-trash.btn-icon
-                | チーム削除
+          td.dropdown
+            a.dropdown-toggle href='#' data-toggle='dropdown' aria-expanded='false'
+              span.glyphicon.glyphicon-cog
+            ul.dropdown-menu
+              li
+                = link_to edit_team_path(team) do
+                  span.glyphicon.glyphicon-wrench.btn-icon
+                  | チーム編集
+              li
+                = link_to team, method: :delete, data: { confirm: '削除してよろしいですか？' }
+                  span.glyphicon.glyphicon-trash.btn-icon
+                  | 削除
 
 .container
   hr

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -31,6 +31,19 @@
                 span.glyphicon.glyphicon-th-list.btn-icon
                 | 目標一覧
 
+          - if team.goals.present?
+            td.right-align
+              = link_to new_team_goal_progress_path(team, team.goals.order(:date).last)
+                button.btn.btn-primary
+                  span.glyphicon.glyphicon-plus.btn-icon
+                  | 最新月に進捗追加
+          - else
+            td.right-align
+              = link_to new_team_goal_path(team)
+                button.btn.btn-primary
+                  span.glyphicon.glyphicon-plus.btn-icon
+                  | 目標の新規登録
+
           td.right-align
             = link_to edit_team_path(team) do
               button.btn.btn-success

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -1,6 +1,8 @@
 .container
   h1
     = "#{@team.name} チーム"
+  h3
+    = "今月の達成度 : #{number_to_currency(@sum, :unit => "", :precision => 0)} / #{number_to_currency(@goal.goal, :unit => "", :precision => 0)} #{@entity} (#{((@sum.to_f/@goal.goal.to_f) * 100).to_i}%)"
 
 .container-preview
   hr

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,20 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-team = FactoryGirl.create(:team)
-goal = FactoryGirl.create(:goal, team: team, date: Date.new(2016,7,1))
+team1 = FactoryGirl.create(:team)
+team2 = FactoryGirl.create(:team)
+goal1 = FactoryGirl.create(:goal, team: team1, date: Date.new(2016,7,1))
+goal2 = FactoryGirl.create(:goal, team: team2, date: Date.new(2016,7,1))
 start_date = Date.new(2016,7,4)
+
 4.times do
   end_date = start_date + 4.days
-  pr = FactoryGirl.create(:progress, goal: goal, start_date: start_date, end_date: end_date)
-  FactoryGirl.create(:topic, progress: pr)
+  pr1 = FactoryGirl.create(:progress, goal: goal1, start_date: start_date, end_date: end_date)
+  FactoryGirl.create(:topic, progress: pr1)
+  pr2 = FactoryGirl.create(:progress, goal: goal2, start_date: start_date, end_date: end_date)
+  FactoryGirl.create(:topic, progress: pr2)
   start_date += 1.weeks
 end
+
+FactoryGirl.create(:shared_info)
+FactoryGirl.create(:shared_info)

--- a/spec/factories/shared_infos.rb
+++ b/spec/factories/shared_infos.rb
@@ -2,9 +2,9 @@
 
 FactoryGirl.define do
   factory :shared_info do
-    title "MyString"
-    owner "MyString"
-    body "MyString"
-    announce_date "2016-08-13"
+    sequence(:title) { |i| "共有事項#{i}" }
+    sequence(:owner) { |i| "発表者#{i}" }
+    sequence(:body) { |i| "共有項目#{i}" }
+    sequence(:announce_date) { Date.current }
   end
 end


### PR DESCRIPTION
issue: #72 

やりたいこと
--
+ [x]  チーム一覧から、最新月の進捗登録ができるようにする。
+ [x] １つも目標を持っていなければ、月の登録に飛ぶ
+ [x] 使用頻度の低い、チーム編集・削除を歯車アイコンのドロップダウンにした

ついでにやっといた
--
+ [x] 新規進捗作成後にプレビューに飛ばす


非常に雑に文言を決めてる感がある。
ボタンを纏める方が良いかとも思ったけど、これ以上操作が変わるのはちょっと避けたいので、ボタンを並べることにした。
文言いい感じのがあれば、欲しいっす。


確認
--

- [x] #69 がマージされたら rebase
